### PR TITLE
Maintain a 'queue order' and display task items accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+.vscode

--- a/app.js
+++ b/app.js
@@ -38,6 +38,20 @@ app.set('view engine', 'pug');
 app.use('/app', requiresAuth, profileRouter);
 app.use(excludesAuth, indexRouter); // ORDER IS IMPORTANT
 
+app.post('/push', (req, res) => {
+    const task = req.body;
+    Queue.push(task).then(result => {
+        res.send(result);
+    })
+});
+
+app.post('/pop', (req, res) => {
+    const type = req.body.group_type;
+    Queue.pop(type).then(result => {
+        res.send(result);
+    })
+});
+
 /* middleware */
 function requiresAuth(req, res, next) {
     if (req.session.userid) {

--- a/migrations/00_create_task_queue.sql
+++ b/migrations/00_create_task_queue.sql
@@ -5,7 +5,7 @@
 drop table if exists task_queue;
 
 create table task_queue (
-    uuid        bigint auto_increment primary key,
+    id          bigint auto_increment primary key,
     next        bigint null,
     group_type  char(1),
     task_type   char(1),
@@ -15,5 +15,5 @@ create table task_queue (
     is_active   int(1) not null default 1,
     expires     datetime,
 
-    foreign key(next) references task_queue(uuid)
+    foreign key(next) references task_queue(id)
 );

--- a/migrations/00_create_task_queue.sql
+++ b/migrations/00_create_task_queue.sql
@@ -13,6 +13,7 @@ create table task_queue (
     descr       varchar(256) not null,
     is_head     int(1) not null default 0,
     is_active   int(1) not null default 1,
+    queue_order bigint not null default 0,
     expires     datetime,
 
     foreign key(next) references task_queue(id)

--- a/migrations/01_dummy_tasks.sql
+++ b/migrations/01_dummy_tasks.sql
@@ -10,6 +10,6 @@ insert into task_queue (group_type, title, descr, is_head, expires)
 insert into task_queue (group_type, title, descr, expires)
     values ('A', 'Animal Task 2', 'This is a test task', '2019-05-25 23:59:59');
 
-update task_queue set next = (select uuid from 
+update task_queue set next = (select id from 
     (select * from task_queue) as queue where queue.is_head = 0 limit 1)
     where is_head = 1;

--- a/migrations/02_additional_tables.sql
+++ b/migrations/02_additional_tables.sql
@@ -21,6 +21,7 @@ create table user (
     salt           char(4) not null,
     score          int default 0,
     cycle_id       bigint null,
+    group_type     char(1) null,
 
     foreign key(cycle_id) references cycle(id)
 );

--- a/migrations/03_dummy_cycle.sql
+++ b/migrations/03_dummy_cycle.sql
@@ -1,0 +1,6 @@
+insert into cycle (total_participants, correct_guesses, score_sum, date_began, date_end)
+    values (0, 0, 0, '2018-05-25 23:59:59', '2019-05-25 23:59:59');
+
+update cycle set total_participants = (select count(id) from user);
+
+update user set cycle_id = (select id from cycle limit 1);

--- a/modules/Queue.js
+++ b/modules/Queue.js
@@ -12,10 +12,6 @@ class Queue extends Model
         return 'task_queue';
     }
 
-    static get idColumn() {
-        return 'uuid';
-    }
-
     static get relationMappings() {
         return {
             nextTask: {
@@ -23,7 +19,7 @@ class Queue extends Model
                 modelClass: Queue,
                 join: {
                     from: 'task_queue.next',
-                    to: 'task_queue.uuid'
+                    to: 'task_queue.id'
                 }
             }
         }
@@ -39,15 +35,15 @@ class Queue extends Model
         
         let oldTail = await Queue.query().where('group_type', '=', task.group_type).andWhere('is_active', '=', 1).whereNull('next').first();
         let newTail, is_head = oldTail ? 0 : 1;
-        if (task.uuid)
-            newTail = await Queue.query().patchAndFetchById(task.uuid, {is_head, is_active: 1});
+        if (task.id)
+            newTail = await Queue.query().patchAndFetchById(task.id, {is_head, is_active: 1});
         else {
             task.is_head = is_head;
             newTail = await Queue.query().insert(task);
         }
 
         return new Promise( (resolve, reject) => {
-            (oldTail || newTail).$query().patch({ next: oldTail ? newTail.uuid : null }).then( result => {
+            (oldTail || newTail).$query().patch({ next: oldTail ? newTail.id : null }).then( result => {
                 resolve(newTail);
             });
         });

--- a/modules/Task.js
+++ b/modules/Task.js
@@ -28,7 +28,7 @@ class Task
         return 'L';
     }
 
-    static get K() { // king
+    static get Q() { // queen
         return 'K';
     }
 }

--- a/modules/User.js
+++ b/modules/User.js
@@ -1,7 +1,7 @@
 require('dotenv').config()
 
 const Model = require('./db.js');
-
+const Cycle = require('./Cycle.js');
 
 class User extends Model
 /**
@@ -10,6 +10,19 @@ class User extends Model
 {
     static get tableName() {
         return 'user';
+    }
+
+    static get relationMappings() {
+        return {
+            cycle: {
+                relation: Model.BelongsToOneRelation,
+                modelClass: Cycle,
+                join: {
+                    from: 'user.cycle_id',
+                    to: 'cycle.id'
+                }
+            }
+        }
     }
 }
 

--- a/modules/db.js
+++ b/modules/db.js
@@ -9,8 +9,7 @@ const knex = require('knex')({
         user: process.env.DB_USER,
         password: process.env.DB_PASSWORD,
         database: process.env.DB
-    },
-    debug: true
+    }
 });
 
 // provide knex connection for all models

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -1,0 +1,40 @@
+html, html * {
+    box-sizing: border-box;
+}
+
+.queue {
+    min-height: 2em;
+    padding: 3px;
+    color: white;
+    margin-bottom: 16px;
+}
+
+.queue .task {
+    border: 1px solid white;
+    padding: 3px;
+    margin-bottom: 8px;
+}
+
+.queue .task:last-of-type {
+    margin-bottom: 0;
+}
+
+.queue[data-type='A'] {
+    background-color: green;
+}
+
+.queue[data-type='S'] {
+    background-color: yellow;
+}
+
+.queue[data-type='K'] {
+    background-color: red;
+}
+
+.queue[data-type='L'] {
+    background-color: pink;
+}
+
+.queue[data-type='Q'] {
+    background-color: purple;
+}

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -2,14 +2,36 @@ const express = require('express');
 const router  = express.Router();
 
 /* dev modules */
-const User = require('../modules/User.js');
+const User  = require('../modules/User.js');
+const Cycle = require('../modules/Cycle.js');
+const Queue = require('../modules/Queue.js');
 
+const currentCycle = Cycle.query().first();
 
+// Maybe shouldn't do it this way... Testing
 router.get('/profile', (req, res) => {
-    User.query().findById(req.session.userid).then( user => {
-        const {identity, score} = user;
-        res.render('profile', { identity, score });
-    })
+    currentCycle.then(cycle => {
+        cycle.$relatedQuery('participants').findById(req.session.userid).then( async user => {
+            const {identity, score, group_type} = user;
+
+            let queues = {
+                none: true,
+                'A': [],
+                'S': [],
+                'K': [],
+                'L': [],
+                'Q': []
+            };
+            if (group_type === 'Q') {
+                users = await Queue.query();
+                users.forEach(task => {
+                    queues[task.group_type].push(task);
+                });
+                delete queues.none;
+            }
+            res.render('profile', { identity, score, group_type, cycle, queues });
+        });
+    });
 });
 
 router.get('/logout', (req, res) => {

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -19,7 +19,6 @@ router.get('/profile', checkExpiration, (req, res) => {
             return;
         }
 
-        console.log('made it');
         let queues = {
             none: true,
             'A': [],
@@ -29,7 +28,7 @@ router.get('/profile', checkExpiration, (req, res) => {
             'Q': []
         };
         if (group_type === 'Q') {
-            tasks = await Queue.query();
+            tasks = await Queue.query().orderBy('queue_order', 'asc');
             tasks.forEach(task => {
                 queues[task.group_type].push(task);
             });

--- a/views/includes/nav.pug
+++ b/views/includes/nav.pug
@@ -1,0 +1,4 @@
+nav
+    ul
+        li #[a(href="/") Home]
+        li #[a(href="/login") Login]

--- a/views/includes/taskQueue.pug
+++ b/views/includes/taskQueue.pug
@@ -2,7 +2,7 @@ h2 Tasks
 each tasks, group_type in queues
     .queue(data-type=group_type)
         each task in tasks
-            .task(class= task.is_head ? 'head' : '', data-expires=task.expires.valueOf() )
+            .task(class= task.is_head ? 'head' : '', data-expires=(task.expires || Date.now()).valueOf() )
                 h3= task.title
                 p=  task.descr
                 footer

--- a/views/includes/taskQueue.pug
+++ b/views/includes/taskQueue.pug
@@ -1,0 +1,12 @@
+h2 Tasks
+each tasks, group_type in queues
+    .queue(data-type=group_type)
+        each task in tasks
+            .task(class= task.is_head ? 'head' : '', data-expires=task.expires.valueOf() )
+                h3= task.title
+                p=  task.descr
+                footer
+                    p
+                        button.push queue
+                        button.pop  remove
+                    span #{task.is_head ? new Date(task.expires) : null}

--- a/views/index.pug
+++ b/views/index.pug
@@ -4,7 +4,5 @@ block content
     include includes/nav.pug
     
     h1 Welcome!
-    p
-        a(href="/login") login 
 
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,6 +1,8 @@
 extends templates/master.pug
 
 block content
+    include includes/nav.pug
+    
     h1 Welcome!
     p
         a(href="/login") login 

--- a/views/login.pug
+++ b/views/login.pug
@@ -1,6 +1,8 @@
 extends templates/master.pug
 
 block content
+    include includes/nav.pug
+    
     form(action="/login", method="POST")
         label(for="name") Identity
         input(type="text", name="identity")

--- a/views/profile.pug
+++ b/views/profile.pug
@@ -5,3 +5,23 @@ block content
     .user #{identity + ' ' + score}
         p
             a(href="/app/logout") logout
+    if !queues.none
+        include includes/taskQueue.pug
+
+block scripts
+    if !queues.none
+        script.
+            const tasks = document.querySelectorAll('.task.head');
+            (function loop() {
+                    setTimeout(loop, 1000);
+                    tasks.forEach(task => {
+                        const remaining = parseInt(task.dataset.expires)- Date.now().valueOf();
+                        const date = {
+                            days: Math.round(remaining / 1000 / 60 / 60 / 24),
+                            mins: Math.round(remaining / 1000 / 60),
+                            secs: Math.round(remaining / 1000)
+                        }
+                        task.querySelector('footer span').innerHTML = `days: ${date.days}, min: ${date.mins}, secs: ${date.secs}`;
+                    })
+                }
+            )();

--- a/views/profile.pug
+++ b/views/profile.pug
@@ -1,15 +1,16 @@
 extends templates/master.pug
 
 block content
+    - let queen = queues && !queues.none;
     h1 Welcome!
-    .user #{identity + ' ' + score}
+    .user #{identity + ' - ' + (!isNaN(score) ? score : "Not a part of the current cycle")}
         p
             a(href="/app/logout") logout
-    if !queues.none
+    if queen
         include includes/taskQueue.pug
 
 block scripts
-    if !queues.none
+    if queen
         script.
             const tasks = document.querySelectorAll('.task.head');
             (function loop() {


### PR DESCRIPTION
So one little wrinkle I encountered was actually displaying tasks to the 'King' or 'Queen' player/role (or whatever) in the appropriate order. Namely, descending by 'next' queue task items. I accomplished by adding a column to the task_queue, 'queue_order' that is maintained via the push and pop operations I have defined over the ORM I am using. Works reasonably well so I figured I'd update master. I have began rethinking the expiration times for task items. Right now for testing, I set the expiration time of the next task item to 5 seconds into the future. This is just for testing so I can actually see the queue update in a reasonable amount of time.